### PR TITLE
Added classes for counting event weights

### DIFF
--- a/alphatwirl/heppyresult/ReadCounter.py
+++ b/alphatwirl/heppyresult/ReadCounter.py
@@ -26,7 +26,7 @@ class ReadCounter(object):
     def _readLine(self, line):
         # a line is written in the format '\t {level:<40} {count:>9} \t {eff1:4.2f} \t {eff2:6.4f}\n'
         # https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_0/PhysicsTools/HeppyCore/python/statistics/counter.py
-        exp = r'^\t (.*?) *([0-9e+-.]*) \t ([0-9e+-.]*) \t ([0-9e+-.]*)$'
+        exp = r'^\t (.*?) *([0-9e+-.]+)\s+([0-9e+-.]+) \t ([0-9e+-.]+)$'
         exp = exp.encode()
         match = re.search(exp, line)
 

--- a/alphatwirl/selection/modules/CountWeight.py
+++ b/alphatwirl/selection/modules/CountWeight.py
@@ -1,0 +1,81 @@
+import copy
+
+##__________________________________________________________________||
+N_KEYS = 3
+IDX_DEPTH = 0
+IDX_PASS = 3
+IDX_TOTAL = 4
+
+##__________________________________________________________________||
+class Count(object):
+    """ Similar to Count.py, but increments by the value in event.w 
+    instead of 1.
+    """
+
+    def __init__(self):
+        self._results = [ ]
+
+    def __repr__(self):
+        return '{}({!r})'.format(self.__class__.__name__, self._results)
+
+    def copy(self):
+        return copy.deepcopy(self)
+
+    def add(self, selection):
+        class_name = selection.__class__.__name__
+        selection_name = selection.name if hasattr(selection, 'name') and selection.name is not None else ''
+        depth = 1
+        pass_ = 0
+        total = 0
+        self._results.append([depth, class_name, selection_name, pass_, total])
+
+    def count(self, pass_, event):
+        for r, p in zip(self._results, pass_):
+            r[IDX_TOTAL] += event.w[0] # total
+            if p: r[IDX_PASS] += event.w[0] # pass
+
+    def increment_depth(self, by = 1):
+        for r in self._results:
+            r[IDX_DEPTH] += by
+
+    def insert(self, i, other):
+        self._results[(i + 1):(i + 1)] = other._results
+
+    def results(self):
+        return self._results
+
+    def __add__(self, other):
+        ret = self.copy()
+
+        if other == 0: # other is 0 when e.g. sum([obj1, obj2])
+            return ret
+
+        self._add_results_inplace(ret._results, other._results)
+        return ret
+
+    def __iadd__(self, other):
+        self._add_results_inplace(self._results, other._results)
+        return self
+
+    def __radd__(self, other):
+        return self.__add__(other)
+
+    def _add_results_inplace(self, res1, res2):
+        if not len(res1) == len(res2):
+            import logging
+            logging.warning('cannot add because res1 and res2 don\'t have the same length: res1 = {}, res2 = {}'.format(res1, res2))
+            return
+
+        if not all([(r1[:N_KEYS] == r2[:N_KEYS]) for r1, r2 in zip(res1, res2)]):
+            import logging
+            logging.warning('cannot add because res1 and res2 don\'t have the same key columns: res1 = {}, res2 = {}'.format(res1, res2))
+            return
+
+        for r1, r2 in zip(res1, res2):
+            r1[IDX_PASS] += r2[IDX_PASS]
+            r1[IDX_TOTAL] += r2[IDX_TOTAL]
+
+    def to_tuple_list(self):
+        return [tuple(e) for e in self._results]
+
+##__________________________________________________________________||

--- a/alphatwirl/selection/modules/CountWeight.py
+++ b/alphatwirl/selection/modules/CountWeight.py
@@ -31,8 +31,8 @@ class Count(object):
 
     def count(self, pass_, event):
         for r, p in zip(self._results, pass_):
-            r[IDX_TOTAL] += event.w[0] # total
-            if p: r[IDX_PASS] += event.w[0] # pass
+            r[IDX_TOTAL] += event.weight[0] # total
+            if p: r[IDX_PASS] += event.weight[0] # pass
 
     def increment_depth(self, by = 1):
         for r in self._results:

--- a/alphatwirl/selection/modules/__init__.py
+++ b/alphatwirl/selection/modules/__init__.py
@@ -1,3 +1,4 @@
 from .basic import All, Any, Not
 from .with_count import AllwCount, AnywCount, NotwCount
+from .with_count_weight import AllwCountWeight, AnywCountWeight, NotwCountWeight
 

--- a/alphatwirl/selection/modules/with_count_weight.py
+++ b/alphatwirl/selection/modules/with_count_weight.py
@@ -1,0 +1,166 @@
+import itertools
+import copy
+
+from .CountWeight import Count
+
+##__________________________________________________________________||
+class AllwCountWeight(object):
+    """select events that meet all conditions
+
+    """
+
+    def __init__(self, name = None):
+        self.name = name if name is not None else 'All'
+        self.selections = [ ]
+        self.count = Count()
+
+    def __repr__(self):
+        return '{}(name = {!r}, selections = {!r}), count = {!r}'.format(
+            self.__class__.__name__,
+            self.name,
+            self.selections,
+            self.count
+        )
+
+    def add(self, selection):
+        self.selections.append(selection)
+        self.count.add(selection)
+
+    def begin(self, event):
+        for s in self.selections:
+            if hasattr(s, 'begin'): s.begin(event)
+
+    def event(self, event):
+        ret = True
+        pass_ = [ ]
+        for s in self.selections:
+            pass_.append(s(event))
+            if not pass_[-1]:
+                ret = False
+                break
+        self.count.count(pass_, event)
+        return ret
+
+    def __call__(self, event):
+        return self.event(event)
+
+    def end(self):
+        for s in self.selections:
+            if hasattr(s, 'end'): s.end()
+
+    def results(self, increment = False):
+
+        ret = self.count.copy()
+
+        # reversed enumerate
+        for i, s in zip(reversed(range(len(self.selections))), reversed(self.selections)):
+            if hasattr(s, 'results'):
+                ret.insert(i, s.results(increment = True))
+
+        if increment:
+            ret.increment_depth(by = 1)
+
+        return ret
+
+##__________________________________________________________________||
+class AnywCountWeight(object):
+    """select events that meet all conditions
+
+    """
+
+    def __init__(self, name = None):
+        self.name = name if name is not None else 'Any'
+        self.selections = [ ]
+        self.count = Count()
+
+    def __repr__(self):
+        return '{}(name = {!r}, selections = {!r}), count = {!r}'.format(
+            self.__class__.__name__,
+            self.name,
+            self.selections,
+            self.count
+        )
+
+    def add(self, selection):
+        self.selections.append(selection)
+        self.count.add(selection)
+
+    def begin(self, event):
+        for s in self.selections:
+            if hasattr(s, 'begin'): s.begin(event)
+
+    def event(self, event):
+        ret = False
+        pass_ = [ ]
+        for s in self.selections:
+            pass_.append(s(event))
+            if pass_[-1]:
+                ret = True
+                break
+        self.count.count(pass_, event)
+        return ret
+
+    def __call__(self, event):
+        return self.event(event)
+
+    def end(self):
+        for s in self.selections:
+            if hasattr(s, 'end'): s.end()
+
+    def results(self, increment = False):
+
+        ret = self.count.copy()
+
+        # reversed enumerate
+        for i, s in zip(reversed(range(len(self.selections))), reversed(self.selections)):
+            if hasattr(s, 'results'):
+                ret.insert(i, s.results(increment = True))
+
+        if increment:
+            ret.increment_depth(by = 1)
+
+        return ret
+
+##__________________________________________________________________||
+class NotwCountWeight(object):
+    """select events that do NOT pass the selection
+
+    """
+
+    def __init__(self, selection, name = None):
+        self.name = name if name is not None else 'Not'
+        self.selection = selection
+        self.count = Count()
+        self.count.add(selection)
+
+    def __repr__(self):
+        return '{}(name = {!r}, selection = {!r}), count = {!r}'.format(
+            self.__class__.__name__,
+            self.name,
+            self.selection,
+            self.count
+        )
+
+    def begin(self, event):
+        if hasattr(self.selection, 'begin'): self.selection.begin(event)
+
+    def event(self, event):
+        pass_ = self.selection(event)
+        self.count.count([pass_], event)
+        return not pass_
+
+    def __call__(self, event):
+        return self.event(event)
+
+    def end(self):
+        if hasattr(self.selection, 'begin'): self.selection.end()
+
+    def results(self, increment = False):
+        ret = self.count.copy()
+        if hasattr(self.selection, 'results'):
+            ret.insert(0, self.selection.results(increment = True))
+        if increment:
+            ret.increment_depth(by = 1)
+        return ret
+
+##__________________________________________________________________||


### PR DESCRIPTION
Added classes that allow the counting of weighted events for the cut flow tables. These use the event.weight number generated in AlphaTools, and the weight used to increment the passing/total number of events should be pulled at the end of the AlphaTools sequence (i.e., should not grab the event weight before all the weights have been applied).

I've made sure these classes are included in __init__ and in alphatwirl-interface. In FAST-RA1, weights can be switched on in the trees2dataframes step, and are off by default.